### PR TITLE
Eduardo: /busca -> fuzzy search (nome e apelido), código de barras e número de edição

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from routers import chamadas
+from routers import chamadas, revista
 
 # Configurações iniciais
 app = FastAPI(
@@ -18,3 +18,4 @@ def ping():
 
 # Outras rotas
 app.include_router(chamadas.router)
+app.include_router(revista.router)

--- a/models/revista_model.py
+++ b/models/revista_model.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+class Revista(BaseModel):
+    id_revista: int
+    nome: str
+    apelido_revista: str | None = None
+    numero_edicao: int
+    codigo_barras: str
+    qtd_estoque: int
+    preco_capa: float
+    preco_liquido: float

--- a/models/revista_model.py
+++ b/models/revista_model.py
@@ -4,8 +4,9 @@ class Revista(BaseModel):
     id_revista: int
     nome: str
     apelido_revista: str | None = None
-    numero_edicao: int
+    numero_edicao: str
     codigo_barras: str
     qtd_estoque: int
     preco_capa: float
     preco_liquido: float
+    score: float | None = None

--- a/routers/revista.py
+++ b/routers/revista.py
@@ -18,43 +18,112 @@ router = APIRouter(
 st = importar_configs()
 supabase: Client = create_client(st.SUPABASE_URL, st.SUPABASE_API_KEY)
 
+def pegar_revistas():
+    try:
+        # Coleta todas as revistas do banco de dados
+        dados = supabase.table("revistas").select("id_revista, nome, apelido_revista, numero_edicao, codigo_barras, qtd_estoque, preco_capa, preco_liquido").execute()
+        return dados
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Erro ao acessar o banco de dados: {str(e)}")
+
 @router.get("/nome")
-def obter_revistas_por_nome_ou_apelido(q: str, user: str = Depends(validar_token)):
+def obter_revistas_por_nome_ou_apelido(q: str, user: dict = Depends(validar_token)):
     """
     Endpoint para obter a(s) revista(s) buscada(s) pelo seu nome ou apelido, utilizando fuzzy search para definir a proximidade do parâmetro de busca com o nome no banco de dados.
     """
     
-    try:
-        dados = supabase.table("Revistas").select("id_revista, nome, apelido_revista, numero_edicao, codigo_barras, qtd_estoque, preco_capa, preco_liquido").execute()
+    dados = pegar_revistas()
         
-        if not dados.data:
-            raise HTTPException(status_code=404, detail="Nenhuma revista encontrada no banco de dados.")
- 
-        revistas = []
-        for item in dados.data:
-            scores = [
-                fuzz.token_sort_ratio(str(q), str(item["nome"])),
-                fuzz.token_sort_ratio(str(q), str(item.get("apelido_revista") or ""))
-            ]
-            max_score = max(scores)
-            
-            if max_score >= 80:
-                revista = Revista(
-                    id_revista=item["id_revista"],
-                    nome=item["nome"],
-                    apelido_revista=item.get("apelido_revista", ""),
-                    numero_edicao=item["numero_edicao"],
-                    codigo_barras=item["codigo_barras"],
-                    qtd_estoque=item["qtd_estoque"],
-                    preco_capa=item["preco_capa"],
-                    preco_liquido=item["preco_liquido"],
-                )
-                revistas.append(revista)
+    if not dados.data:
+        raise HTTPException(status_code=404, detail="Nenhuma revista encontrada no banco de dados.")
+
+    revistas = []
+    for item in dados.data:
+        # Cálculo da similaridade usando RapidFuzz, usando .lower e .strip para melhorar a correspondência
+        scores = [
+            fuzz.token_sort_ratio(str(q).lower().strip(), str(item["nome"]).lower().strip()),
+            fuzz.token_sort_ratio(str(q).lower().strip(), str(item.get("apelido_revista") or "").lower().strip())
+        ]
+
+        # Já que nome e apelido são considerados ao mesmo tempo, pega apenas o maior valor de similaridade
+        max_score = max(scores)
         
-        if not revistas:
-            raise HTTPException(status_code=404, detail="Nenhuma revista encontrada com o nome fornecido.")
+        if max_score >= 70:
+            # Considera uma correspondência válida se a similaridade for 70 ou mais e adiciona a revista na lista de resultados
+            revista = Revista(
+                id_revista=item["id_revista"],
+                nome=item["nome"],
+                apelido_revista=item.get("apelido_revista", ""),
+                numero_edicao=item["numero_edicao"],
+                codigo_barras=item["codigo_barras"],
+                qtd_estoque=item["qtd_estoque"],
+                preco_capa=item["preco_capa"],
+                preco_liquido=item["preco_liquido"],
+                score=max_score
+            )
+            revistas.append(revista)
+    
+    if not revistas:
+        raise HTTPException(status_code=404, detail="Nenhuma revista encontrada com o nome fornecido.")
+    
+    return revistas
+
+@router.get("/codigo-barras")
+def obter_revista_por_codigo_barras(q: str, user: dict = Depends(validar_token)):
+    """
+    Endpoint para obter a revista buscada pelo seu código de barras.
+    """
+    
+    dados = pegar_revistas()
         
-        return revistas
-            
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Erro ao acessar o banco de dados: {str(e)}")
+    if not dados.data:
+        raise HTTPException(status_code=404, detail="Nenhuma revista encontrada no banco de dados.")
+
+    for item in dados.data:
+        # Busca exata pelo código de barras, removendo espaços em branco com .strip
+        if str(item["codigo_barras"]).strip() == str(q).strip():
+            revista = Revista(
+                id_revista=item["id_revista"],
+                nome=item["nome"],
+                apelido_revista=item.get("apelido_revista", ""),
+                numero_edicao=item["numero_edicao"],
+                codigo_barras=item["codigo_barras"],
+                qtd_estoque=item["qtd_estoque"],
+                preco_capa=item["preco_capa"],
+                preco_liquido=item["preco_liquido"]
+            )
+            return revista
+    
+    raise HTTPException(status_code=404, detail="Nenhuma revista encontrada com o código de barras fornecido.")
+
+@router.get("/edicao")
+def obter_revista_por_edicao(q: str, user: dict = Depends(validar_token)):
+    """
+    Endpoint para obter a revista buscada pelo seu número de edição.
+    """
+    
+    dados = pegar_revistas()
+        
+    if not dados.data:
+        raise HTTPException(status_code=404, detail="Nenhuma revista encontrada no banco de dados.")
+
+    revistas = []
+    for item in dados.data:
+        # Busca exata pelo número de edição, removendo espaços em branco com .strip
+        if str(item["numero_edicao"]).strip() == str(q).strip():
+            revista = Revista(
+                id_revista=item["id_revista"],
+                nome=item["nome"],
+                apelido_revista=item.get("apelido_revista", ""),
+                numero_edicao=item["numero_edicao"],
+                codigo_barras=item["codigo_barras"],
+                qtd_estoque=item["qtd_estoque"],
+                preco_capa=item["preco_capa"],
+                preco_liquido=item["preco_liquido"]
+            )
+            revistas.append(revista) # Como mais de uma revista pode ter a mesma edição, adiciona na lista
+    
+    if not revistas:
+        raise HTTPException(status_code=404, detail="Nenhuma revista encontrada com o número de edição fornecido.")
+    
+    return revistas

--- a/routers/revista.py
+++ b/routers/revista.py
@@ -1,0 +1,60 @@
+from fastapi import APIRouter, HTTPException,  Depends
+from supabase import Client, create_client
+
+from models.revista_model import Revista
+
+from settings.settings import importar_configs
+from services.auth import validar_token
+
+from rapidfuzz import fuzz
+
+
+# Configurações iniciais
+router = APIRouter(
+    prefix="/busca",
+    tags=["Busca"]
+)
+
+st = importar_configs()
+supabase: Client = create_client(st.SUPABASE_URL, st.SUPABASE_API_KEY)
+
+@router.get("/nome")
+def obter_revistas_por_nome_ou_apelido(q: str, user: str = Depends(validar_token)):
+    """
+    Endpoint para obter a(s) revista(s) buscada(s) pelo seu nome ou apelido, utilizando fuzzy search para definir a proximidade do parâmetro de busca com o nome no banco de dados.
+    """
+    
+    try:
+        dados = supabase.table("Revistas").select("id_revista, nome, apelido_revista, numero_edicao, codigo_barras, qtd_estoque, preco_capa, preco_liquido").execute()
+        
+        if not dados.data:
+            raise HTTPException(status_code=404, detail="Nenhuma revista encontrada no banco de dados.")
+ 
+        revistas = []
+        for item in dados.data:
+            scores = [
+                fuzz.token_sort_ratio(str(q), str(item["nome"])),
+                fuzz.token_sort_ratio(str(q), str(item.get("apelido_revista") or ""))
+            ]
+            max_score = max(scores)
+            
+            if max_score >= 80:
+                revista = Revista(
+                    id_revista=item["id_revista"],
+                    nome=item["nome"],
+                    apelido_revista=item.get("apelido_revista", ""),
+                    numero_edicao=item["numero_edicao"],
+                    codigo_barras=item["codigo_barras"],
+                    qtd_estoque=item["qtd_estoque"],
+                    preco_capa=item["preco_capa"],
+                    preco_liquido=item["preco_liquido"],
+                )
+                revistas.append(revista)
+        
+        if not revistas:
+            raise HTTPException(status_code=404, detail="Nenhuma revista encontrada com o nome fornecido.")
+        
+        return revistas
+            
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Erro ao acessar o banco de dados: {str(e)}")


### PR DESCRIPTION
Endpoint base /busca, com subendpoints para realizar a busca de revistas por meio dos parâmetros:

- Nome ou apelido (busca usando RapidFuzz para determinar proximidade entre os nomes)
- Código de barras (busca exata e única)
- Número da edição (busca exata e múltipla)