### PR TITLE
padronizacão dos payloads + /documentations

### DIFF
--- a/documentation/dotenvfile.md
+++ b/documentation/dotenvfile.md
@@ -1,0 +1,7 @@
+```
+SUPABASE_URL = "Project Settings -> Data API -> Project URL -> URL"
+SUPABASE_API_KEY = "Project Settings -> API Keys -> Legacy API Keys -> anon public"
+SUPABASE_JWT = "Project Settings -> JWT Keys -> Legacy JWT Secret -> Legacy JWT secret"
+BUCKET = "docs"
+BUCKET_REVISTAS = "revistas"
+```

--- a/documentation/payloads.md
+++ b/documentation/payloads.md
@@ -1,0 +1,36 @@
+# Padronização de Payloads da AndreaControllerAPI
+
+Este documento estabelece o padrão para os payloads de requisição e resposta da API, visando a consistência e a clareza na comunicação entre o cliente e o servidor.
+
+## 1. Payload Padrão de Sucesso
+
+Toda resposta de sucesso (HTTP status `2xx`) deve seguir a estrutura abaixo. Isso garante que o cliente sempre saiba onde encontrar os dados principais da resposta.
+
+**Estrutura:**
+
+```json
+{
+  "data": <tipo_variado>,
+  "message": "string"
+}
+```
+
+- **`data`**: Contém o corpo principal da resposta. Pode ser um objeto, um array de objetos ou `null` caso o endpoint não retorne dados (ex: em uma operação de cadastro que retorna apenas uma mensagem).
+  - Para GET, mostra o conteúdo pedido;
+  - Para POST, contém null;
+- **`message`**: Uma mensagem descritiva sobre o sucesso da operação.
+
+## 2. Payload Padrão de Erro
+
+A principal regra é **sempre utilizar as constantes de status do módulo `fastapi.status`** para garantir a consistência dos códigos.
+
+**Estrutura:**
+
+```json
+{
+  "detail": "string"
+}
+```
+
+- **`detail`**: Uma mensagem clara e concisa sobre o erro que ocorreu.
+  - Para 500 (Internal Server Error), ele passa os details

--- a/main.py
+++ b/main.py
@@ -26,7 +26,10 @@ def ping():
         if con:
             return JSONResponse(
                 status_code=status.HTTP_200_OK,
-                content="Pong!"
+                content={
+                    "data": "Pong!",
+                    "message": "Conexão com o banco de dados bem-sucedida."
+                }
             )
     except Exception as e:
         raise HTTPException(
@@ -41,7 +44,10 @@ def ping():
         if con:
             return JSONResponse(
                 status_code=status.HTTP_200_OK,
-                content="Pong!"
+                content={
+                    "data": "Pong!",
+                    "message": "Conexão com o banco de dados bem-sucedida."
+                }
             )
     except Exception as e:
         raise HTTPException(

--- a/routers/chamadas.py
+++ b/routers/chamadas.py
@@ -128,10 +128,12 @@ async def cadastrar_chamada(file: UploadFile = File(...), user: dict = Depends(v
     revistas_inseridas = _cadastrar_revistas_db(chamada_json, supabase_admin, id_chamada_criada)
     
     return {
-        "mensagem": "Chamada criada e revistas cadastradas com sucesso.",
-        "id_chamada": id_chamada_criada,
-        "url_documento": url_assinada,
-        "qtd_revistas_cadastradas": revistas_inseridas
+        "data": {
+            "id_chamada": id_chamada_criada,
+            "url_documento": url_assinada,
+            "qtd_revistas_cadastradas": revistas_inseridas
+        },
+        "message": "Chamada criada e revistas cadastradas com sucesso."
     }
 
 @router.get("/listar-chamadas-usuario")
@@ -147,7 +149,10 @@ async def listar_chamadas_por_usuario(user: dict = Depends(validar_token), supab
             .order("data_limite", desc=True)
             .execute()
         )
-        return resposta.data
+        return {
+            "data": resposta.data,
+            "message": "Chamadas do usuário listadas com sucesso."
+        }
     except Exception as e:
         print(f"Erro ao buscar chamadas no Supabase: {e}")
         raise HTTPException(

--- a/routers/revistas.py
+++ b/routers/revistas.py
@@ -27,7 +27,10 @@ def pegar_revistas():
 
 @router.get("/tudo")
 def pegar_tudo(user = Depends(validar_token)):
-    return pegar_revistas().data
+    return {
+        "data": pegar_revistas().data,
+        "message": "Revistas listadas com sucesso."
+    }
 
 @router.get("/buscar/nome")
 def obter_revistas_por_nome_ou_apelido(q: str, user: dict = Depends(validar_token)):
@@ -69,7 +72,10 @@ def obter_revistas_por_nome_ou_apelido(q: str, user: dict = Depends(validar_toke
     if not revistas:
         raise HTTPException(status_code=404, detail="Nenhuma revista encontrada com o nome fornecido.")
     
-    return revistas
+    return {
+        "data": revistas,
+        "message": "Revistas encontradas com sucesso."
+    }
 
 @router.get("/buscar/codigo-barras")
 def obter_revista_por_codigo_barras(q: str, user: dict = Depends(validar_token)):
@@ -95,7 +101,10 @@ def obter_revista_por_codigo_barras(q: str, user: dict = Depends(validar_token))
                 preco_capa=item["preco_capa"],
                 preco_liquido=item["preco_liquido"]
             )
-            return revista
+            return {
+                "data": revista,
+                "message": "Revista encontrada com sucesso."
+            }
     
     raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Nenhuma revista encontrada com o código de barras fornecido.")
 
@@ -129,11 +138,13 @@ def obter_revista_por_edicao(q: str, user: dict = Depends(validar_token)):
     if not revistas:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Nenhuma revista encontrada com o número de edição fornecido.")
     
-    return revistas
+    return {
+        "data": revistas,
+        "message": "Revistas encontradas com sucesso."
+    }
 
 @router.post("/cadastrar-foto")
 async def upload_image(codigo: int, imagem: UploadFile = File(...), user: dict = Depends(validar_token)):
-    # Crie um nome pardonizado para a imagem
     extensao = imagem.filename.split('.')[-1] if '.' in imagem.filename else 'jpg'
     caminho = f"img_{codigo}.{extensao}"
     file_bytes = await imagem.read()
@@ -151,9 +162,11 @@ async def upload_image(codigo: int, imagem: UploadFile = File(...), user: dict =
         }).eq('codigo_barras', codigo).execute()
         
         return {
-            "caminho_bucket": caminho,
-            "url": url,
-            "database_updated": len(response.data) > 0,
+            "data": {
+                "caminho_bucket": caminho,
+                "url": url,
+                "database_updated": len(response.data) > 0,
+            },
             "message": "Imagem enviada e banco atualizado com sucesso"
         }
     except Exception as e:

--- a/routers/vendas.py
+++ b/routers/vendas.py
@@ -21,7 +21,10 @@ supabase: Client = create_client(st.SUPABASE_URL, st.SUPABASE_API_KEY)
 def pegar_vendas(user = Depends(validar_token)):
     try:
         dados = supabase.table("vendas").select("id_venda, id_usuario, id_produto, metodo_pagamento, qtd_vendida, desconto_aplicado, valor_total, data_venda").execute()
-        return dados.data
+        return {
+            "data": dados.data,
+            "message": "Vendas listadas com sucesso."
+        }
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Erro ao acessar o banco de dados: {str(e)}")
 
@@ -29,7 +32,10 @@ def pegar_vendas(user = Depends(validar_token)):
 def pegar_relatorio_dia(user = Depends(validar_token)):
     try:
         recentes = supabase.table("vw_vendas_recentes").select("*").execute()
-        return recentes.data
+        return {
+            "data": recentes.data,
+            "message": "Relatório de vendas recentes gerado com sucesso."
+        }
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -40,7 +46,10 @@ def pegar_relatorio_dia(user = Depends(validar_token)):
 def pegar_hoje(user = Depends(validar_token)):
     try:
         vendas_hoje = supabase.table("vw_vendas_hoje").select("*").execute()
-        return vendas_hoje.data
+        return {
+            "data": vendas_hoje.data,
+            "message": "Vendas de hoje listadas com sucesso."
+        }
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -85,7 +94,10 @@ def cadastrar_venda_codigo(venda: VendaFormularioCodBarras, user: dict = Depends
     if resposta_insert.data:
         return JSONResponse(
             status_code=status.HTTP_200_OK,
-            content={"mensagem": "Venda cadastrada com sucesso!"}
+            content={
+                "data": None,
+                "message": "Venda cadastrada com sucesso!"
+            }
         )
     else:
         raise HTTPException(
@@ -123,7 +135,10 @@ def cadastrar_venda_id(venda: VendaFormularioId, user: dict = Depends(validar_to
     if resposta_insert.data:
         return JSONResponse(
             status_code=status.HTTP_200_OK,
-            content={"mensagem": "Venda cadastrada com sucesso!"}
+            content={
+                "data": None,
+                "message": "Venda cadastrada com sucesso!"
+            }
         )
     else:
         raise HTTPException(
@@ -137,7 +152,10 @@ def cadastrar_venda_id(venda: VendaFormularioId, user: dict = Depends(validar_to
 def pegar_relatorio_semana(user = Depends(validar_token)):
     try:
         vendas_semana = supabase.table("mv_performance_semanal").select("*").execute()
-        return vendas_semana.data
+        return {
+            "data": vendas_semana.data,
+            "message": "Relatório semanal de vendas gerado com sucesso."
+        }
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
Adicionei a pasta documentations para documentar os payloads e aproveitei para adicionar um guia para o .env

Sucesso:
{
  "data": <tipo_variado>,
  "message": "string"
}


Erro:
{
  "detail": "string" (se internal server error <e>)
}
